### PR TITLE
Update @planship/vue to 0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@planship/nuxt",
-  "version": "0.3.0",
+  "version": "0.3.3",
   "description": "Planship SDK for Nuxt",
   "repository": "https://github.com/planship/planship-nuxt",
   "author": "pawel@planship.io",
@@ -23,11 +23,12 @@
     "release": "npm run lint && npm run test && npm run prepack && changelogen --release && npm publish && git push --follow-tags",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
-    "publish:alpha": "pnpm build && pnpm publish --tag alpha --no-git-checks"
+    "publish:alpha": "pnpm build && pnpm publish --tag alpha --no-git-checks",
+    "publish:latest": "pnpm build && pnpm publish"
   },
   "dependencies": {
     "@nuxt/kit": "^3.12.3",
-    "@planship/vue": "0.3.0",
+    "@planship/vue": "0.3.3",
     "defu": "^6.1.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^3.12.3
     version: 3.12.3(magicast@0.3.4)(rollup@3.29.4)
   '@planship/vue':
-    specifier: 0.3.0
-    version: 0.3.0
+    specifier: 0.3.3
+    version: 0.3.3
   defu:
     specifier: ^6.1.4
     version: 6.1.4
@@ -1986,20 +1986,20 @@ packages:
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
     dev: true
 
-  /@planship/fetch@0.3.0-alpha3:
-    resolution: {integrity: sha512-ZRHJFKPpYUv7AHXXiwto1KIHSvjNAVra6EPGKFiTtRb1p0BirdUNxmXgyojLVx5zozmrmrq5AH91qsASGf/5pg==}
+  /@planship/fetch@0.3.2:
+    resolution: {integrity: sha512-u9AhXxttCt/J2+Q++uxqFGliPWedk5gSXoMMKKSSRUJJLIC4i+rYZHYN6643VheCaVrIZmeg5cngVUSEHfT4dQ==}
     dependencies:
-      '@planship/models': 0.3.0-alpha3
+      '@planship/models': 0.3.2
     dev: false
 
-  /@planship/models@0.3.0-alpha3:
-    resolution: {integrity: sha512-oEw/qdmaYX8hZB3HpVTDgFoFdtXtT4DrCqUeLU10dBhcgLNRCOLW2z8HbM+ww6yPwpNc4oY5iVF1VFJrlUz9aA==}
+  /@planship/models@0.3.2:
+    resolution: {integrity: sha512-PMfuIegyXIIReoQ6mo11HcNG0eGwZQRN6YKYlGcGHNzPyg8Ls2rBWqEtMo3Him956HlE3RmyYmO4oO89ejCo4Q==}
     dev: false
 
-  /@planship/vue@0.3.0:
-    resolution: {integrity: sha512-glLYe0fliE/a1QNkTJwALknkf6Erz2kfLNtgBIl7BaCa/bJAffSeVYSW1r+LcmFKPmFO6tQnayGSuf/Uz7MF4Q==}
+  /@planship/vue@0.3.3:
+    resolution: {integrity: sha512-FE+622Xpq59kbNcpg6rxC7kpiJmJnGCJ1YBRY76uy2bO7ANrbA00hBdySlwTTX7VBtrt/tQo3QlxY/B0H2R5cg==}
     dependencies:
-      '@planship/fetch': 0.3.0-alpha3
+      '@planship/fetch': 0.3.2
     dev: false
 
   /@polka/url@1.0.0-next.25:
@@ -2866,7 +2866,7 @@ packages:
       '@vue/shared': 3.4.38
       estree-walker: 2.0.2
       magic-string: 0.30.11
-      postcss: 8.4.43
+      postcss: 8.4.44
       source-map-js: 1.2.0
     dev: true
 
@@ -6554,8 +6554,8 @@ packages:
       source-map-js: 1.2.0
     dev: true
 
-  /postcss@8.4.43:
-    resolution: {integrity: sha512-gJAQVYbh5R3gYm33FijzCZj7CHyQ3hWMgJMprLUlIYqCwTeZhBQ19wp0e9mA25BUbEvY5+EXuuaAjqQsrBxQBQ==}
+  /postcss@8.4.44:
+    resolution: {integrity: sha512-Aweb9unOEpQ3ezu4Q00DPvvM2ZTUitJdNKeP/+uQgr1IBIqu574IaZoURId7BKtWMREwzKa9OgzPzezWGPWFQw==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
       nanoid: 3.3.7


### PR DESCRIPTION
This PR, when merged, will update @planship/vue version to 0.3.2. Version 0.3.2 contains a fix for missing .js extensions problem introduced in version 0.3.0 (ESM Module requirement)

Related PR: https://github.com/planship/planship-vue/pull/2